### PR TITLE
adding wild card users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,11 @@ RUN echo "postfix postfix/main_mailer_type string 'Internet Site'" | debconf-set
     echo "postfix postfix/mailname string 'localhost'" | debconf-set-selections && \
     postconf -e 'inet_interfaces = all' && \
     postconf -e 'mydestination = localhost, local.ingest.lets.qa' && \
-    postconf -e 'virtual_alias_domains = local.ingest.lets.qa' && \
-    postconf -e 'virtual_alias_maps = hash:/etc/postfix/virtual' && \
-    echo "automation@local.ingest.lets.qa root" > /etc/postfix/virtual && \
-    postmap /etc/postfix/virtual && \
-    newaliases
+    postconf -e "virtual_alias_domains =" && \
+    postconf -e "virtual_alias_maps = regexp:/etc/postfix/virtual_alias_maps"
+
+RUN echo "/.*/    root@local.ingest.lets.qa" > /etc/postfix/virtual_alias_maps
+RUN postmap /etc/postfix/virtual_alias_maps
 
 # Expose the SMTP port
 EXPOSE 25

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN echo "postfix postfix/main_mailer_type string 'Internet Site'" | debconf-set
     postconf -e "virtual_alias_domains =" && \
     postconf -e "virtual_alias_maps = regexp:/etc/postfix/virtual_alias_maps"
 
-RUN echo "/.*/    root@local.ingest.lets.qa" > /etc/postfix/virtual_alias_maps
+RUN echo "/.*/    root" > /etc/postfix/virtual_alias_maps
 RUN postmap /etc/postfix/virtual_alias_maps
 
 # Expose the SMTP port

--- a/test_wild_user.sh
+++ b/test_wild_user.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Define the SMTP server and port
+SMTP_SERVER="localhost"
+SMTP_PORT=25
+
+# Define the email details
+FROM_EMAIL="automation@local.ingest.lets.qa"
+TO_EMAIL="anything@local.ingest.lets.qa"
+SUBJECT="Test Email"
+BODY="This is a test email sent via telnet."
+
+# Use telnet to connect to the SMTP server and simulate an SMTP transaction
+(
+echo "open $SMTP_SERVER $SMTP_PORT"
+sleep 2
+echo "HELO $SMTP_SERVER"
+sleep 2
+echo "MAIL FROM:<$FROM_EMAIL>"
+sleep 2
+echo "RCPT TO:<$TO_EMAIL>"
+sleep 2
+echo "DATA"
+sleep 2
+echo "Subject: $SUBJECT"
+echo "$BODY"
+echo "."
+sleep 2
+echo "QUIT"
+) | telnet


### PR DESCRIPTION
any user@ the test domain will be accepted and forwarded to the root mailbox

➜  local-test-mail-server git:(add-wildcard-users) sh test_wild_user.sh
telnet> Trying ::1...
Connected to localhost.
Escape character is '^]'.
220 localhost ESMTP Postfix (Ubuntu)
250 localhost
250 2.1.0 Ok
250 2.1.5 Ok
354 End data with <CR><LF>.<CR><LF>
250 2.0.0 Ok: queued as 2C673367E3A
Connection closed by foreign host.
➜  local-test-mail-server git:(add-wildcard-users) 

➜  mail cat root
cat: root: No such file or directory
➜  mail cat root
From automation@local.ingest.lets.qa  Mon Oct  7 18:56:05 2024
Return-Path: <automation@local.ingest.lets.qa>
X-Original-To: anything@local.ingest.lets.qa
Delivered-To: root@local.ingest.lets.qa
Received: from localhost (unknown [192.168.65.1])
	by localhost (Postfix) with SMTP id 2C673367E3A
	for <anything@local.ingest.lets.qa>; Mon,  7 Oct 2024 18:55:59 +0000 (UTC)
Subject: Test Email

This is a test email sent via telnet.

➜  mail 
